### PR TITLE
Dev container: host mounts for gh, Claude Code, SSH, and git (#117)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:22
+
+USER root
+
+RUN npm install -g @anthropic-ai/claude-code \
+  && npm cache clean --force
+
+USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
   "name": "Triton Droids Website Container",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,16 @@
   "name": "Triton Droids Website Container",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
   "features": {
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
+  "mounts": [
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/node/.ssh,type=bind,consistency=cached",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.gitconfig,target=/home/node/.gitconfig,type=bind,consistency=cached",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.config/gh,target=/home/node/.config/gh,type=bind,consistency=cached",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.config/git,target=/home/node/.config/git,type=bind,consistency=cached",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.claude,target=/home/node/.claude,type=bind,consistency=cached"
+  ],
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
## Related

Closes #117

## Status

**Draft** — this PR was opened to track [issue #117](https://github.com/triton-droids/website/issues/117). Implementation of `.devcontainer/devcontainer.json` mounts (GitHub CLI, Claude Code, SSH keys, git config) will be added in follow-up commits on this branch.

## Planned work (from issue)

- Mount host `gh` config/state
- Mount Claude Code–related paths from the host
- Mount `~/.ssh`
- Mount git global config (and related paths)

See the issue for acceptance criteria and security notes.

## Follow-up: Claude Code CLI in the image

**Best practice — bake it into the image:** Using `postCreateCommand` to install the Claude Code CLI works but reinstalls on every rebuild, which is slow. Better to use a **`Dockerfile`** with a dedicated `RUN` step so the install is a **cached layer**.

Made with [Cursor](https://cursor.com)
