### PR TITLE
Add Dependabot configuration for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    labels:
+      - "dependencies"
+    groups:
+      all-npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with weekly automated updates for:
  - npm packages (grouped into a single PR for all dependencies)
  - GitHub Actions

> **Note:** Enabling Dependabot alerts, secret scanning, and the dependency graph requires repo admin access in GitHub Settings → Security — those are one-time manual steps and cannot be done via code.

Closes #113

🤖 Generated with Claude Code