### PR TITLE
Fix issue template URL: .com → .org/

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Triton Droids Website
-    url: https://tritondroids.com
+    url: https://tritondroids.org/
     about: Visit the live site


### PR DESCRIPTION
## Summary
- Corrects the Triton Droids website URL in the GitHub issue template from `tritondroids.com` to `tritondroids.org/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)