### PR TITLE
Fix invalid YAML in Cloudflare Pages deploy workflow

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -42,4 +42,6 @@ jobs:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Print deployment URL
-        run: echo "Deployment URL: ${{ steps.pages-deploy.outputs.deployment-url }}"
+        env:
+          DEPLOYMENT_URL: ${{ steps.pages-deploy.outputs.deployment-url }}
+        run: echo "Deployment URL: ${DEPLOYMENT_URL}"


### PR DESCRIPTION
## Summary
GitHub Actions rejected `.github/workflows/cloudflare-pages.yml` with **Invalid workflow file** / YAML syntax error on the step that printed the deployment URL.

## Cause
Nested `${{ }}` inside a quoted `run:` string (with a colon in the echo text) confused the workflow YAML parser.

## Fix
Pass `steps.pages-deploy.outputs.deployment-url` via `env:` and echo `${DEPLOYMENT_URL}` so the `run` line stays plain shell.

## Test plan
- [ ] Confirm workflow file validates in GitHub (no “Invalid workflow file”)
- [ ] Run `Deploy to Cloudflare Pages` on merge if applicable

Made with [Cursor](https://cursor.com)