### PR TITLE
Fix Cloudflare Pages workflow YAML at line 47

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -44,4 +44,5 @@ jobs:
       - name: Print deployment URL
         env:
           DEPLOYMENT_URL: ${{ steps.pages-deploy.outputs.deployment-url }}
-        run: echo "Deployment URL: ${DEPLOYMENT_URL}"
+        run: |
+          echo "Deployment URL: $DEPLOYMENT_URL"


### PR DESCRIPTION
## Summary
- Switch the deployment URL print step to block-scalar `run: |` syntax in `.github/workflows/cloudflare-pages.yml`.
- Keep the expression value in `env` and use shell variable expansion in the command.
- Avoid YAML parsing ambiguity that can trigger "Invalid workflow file" errors around line 47.

## Test plan
- [x] Parse the workflow YAML locally with `js-yaml`
- [ ] Push branch and verify GitHub Actions accepts workflow syntax
- [ ] Trigger workflow manually with `workflow_dispatch`

Made with [Cursor](https://cursor.com)