### PR TITLE
fix(assets): remove GLB LFS rules that broke CI deploys

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Force LF for text files
 * text=auto eol=lf
 
-# Git LFS for large binary assets
-*.glb filter=lfs diff=lfs merge=lfs -text
-*.gltf filter=lfs diff=lfs merge=lfs -text
+# GLB/GLTF treated as binary (no line-ending conversion)
+*.glb -text
+*.gltf -text


### PR DESCRIPTION
## What happened

PR #122 added `.gitattributes` rules to mark `*.glb` and `*.gltf` files as Git LFS-tracked, as a first step toward moving the 3D model files (~42 MB) out of the repo. However, the files were **never actually migrated into LFS storage** — they remain as regular git blobs in the repository history.

The `cloudflare/wrangler-action@v3` checkout step runs with LFS enabled, so on every PR it tried to pull the GLB files from LFS storage. Since they don't exist there, it failed with:

```
error: failed to fetch some objects from '.../info/lfs'
```

This caused the deploy job to fail on all PRs (most visibly on #144), making the GLB/3D model files appear missing from preview deployments.

## Fix

Removes the `filter=lfs diff=lfs merge=lfs` attributes from `*.glb` and `*.gltf`. Keeps `-text` so git treats them as binary and won't mangle line endings.

The GLB files were never in LFS — they're still safely stored as regular git objects and will be checked out normally again.

## Future LFS migration

If we want to actually move the GLBs into LFS to shrink repo history, the steps are:
1. Install `git-lfs` locally
2. Run `git lfs migrate import --include="*.glb,*.gltf" --everything`
3. Force-push and have all teammates re-clone

That's a coordinated breaking change, so leaving it for a dedicated effort.

## Test plan
- [x] `npm run build` passes locally
- [x] Deploy check passes on this PR (no LFS fetch error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)