### PR TITLE
fix(projects): preload project images on mount

### DIFF
--- a/src/pages/Projects/ProjectsSection.tsx
+++ b/src/pages/Projects/ProjectsSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import humanoidIconBlue from '../../assets/projects/humanoid-icon-blue.svg';
 import {
@@ -60,6 +60,12 @@ const projects: ProjectData[] = [
 
 export default function ProjectsSection() {
   const [activeProject, setActiveProject] = useState(0);
+
+  useEffect(() => {
+    projects.forEach((p) => {
+      new Image().src = p.image;
+    });
+  }, []);
 
   const project = projects[activeProject];
 


### PR DESCRIPTION
## Summary
- Adds a `useEffect` on mount in `ProjectsSection` that preloads all three project images via `new Image().src`
- Eliminates the brief delay when switching project tabs, since images are cached before the user interacts

## Test plan
- [x] Visit the home page and click through the Humanoid, Learning Projects, and RoboCup tabs — images should swap instantly with no flash/delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)