### PR TITLE
fix(projects): match humanoid intro text size to card body text

### DIFF
--- a/src/pages/Projects/Humanoid.tsx
+++ b/src/pages/Projects/Humanoid.tsx
@@ -68,10 +68,7 @@ export default function Humanoid() {
         <section className="flex flex-col gap-5 md:gap-10 items-start px-4 py-5 md:px-12 lg:px-16 xl:px-20 w-full max-w-7xl mx-auto">
           <div className="flex flex-col gap-2 md:gap-4 lg:gap-6 items-start w-full">
             <HeroHeading>{humanoidProject.title}</HeroHeading>
-            <BodyText
-              size="lg"
-              className="text-xs leading-normal md:text-lg md:leading-relaxed max-w-4xl"
-            >
+            <BodyText className="max-w-4xl">
               {humanoidProject.description}
             </BodyText>
           </div>


### PR DESCRIPTION
## Summary
- remove custom text-size overrides from the Humanoid hero description paragraph
- use shared `BodyText` defaults so the intro paragraph matches project card body text sizing across breakpoints
- keep the existing `max-w-4xl` constraint for layout consistency

## Test plan
- [x] Run pre-commit hooks (eslint + prettier via lint-staged)
- [x] Verify `src/pages/Projects/Humanoid.tsx` compiles and lints clean
- [x] Visually verify `/projects/humanoid` intro paragraph text size matches card description text

Made with [Cursor](https://cursor.com)