### PR TITLE
UI: About mobile two-column profile layouts & executive cards (closes #104)

### DIFF
--- a/src/components/AlumniMemberCard.tsx
+++ b/src/components/AlumniMemberCard.tsx
@@ -31,25 +31,17 @@ export default function AlumniMemberCard({ member }: AlumniMemberCardProps) {
       </section>
 
       {/* Text Section */}
-      <section className="w-full bg-main-bg rounded-b-card px-6 pt-3 pb-4 text-left">
+      <section className="w-full bg-main-bg rounded-b-card px-2 pt-2 pb-3 sm:px-6 sm:pt-3 sm:pb-4 text-left">
         {/* White Name Text */}
-        <h3 className="text-xl font-bold text-white mb-0 leading-tight">
+        <h3 className="text-sm sm:text-base md:text-xl font-bold text-white mb-0 leading-tight">
           {member.name}
         </h3>
 
-        {/* Light Grey Role Text */}
-        <p
-          className="text-sm font-bold uppercase mb-0 leading-tight"
-          style={{ color: '#9CA3AF' }}
-        >
+        <p className="text-xs sm:text-sm font-bold uppercase mb-0 leading-tight text-muted-text">
           {member.role}
         </p>
 
-        {/* Light Grey Academic Year Text */}
-        <p
-          className="text-sm font-medium mb-0 leading-tight"
-          style={{ color: '#9CA3AF' }}
-        >
+        <p className="text-xs sm:text-sm font-medium mb-0 leading-tight text-muted-text">
           {member.academicYear}
         </p>
       </section>

--- a/src/components/TeamMemberCard.tsx
+++ b/src/components/TeamMemberCard.tsx
@@ -24,6 +24,77 @@ const LinkedInIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
+function ExecutiveCard({ member }: { member: TeamMember }) {
+  return (
+    <article
+      className="rounded-card border-2 border-gray-600 bg-main-bg w-full text-left overflow-hidden"
+      style={{
+        boxShadow:
+          '0 0 20px rgba(75, 85, 99, 0.4), 0 0 40px rgba(75, 85, 99, 0.2)',
+      }}
+    >
+      {/* Mobile V2: portrait left, role / name / bio right — no hover motion */}
+      <div className="flex flex-row gap-4 items-start p-4 md:flex-col md:gap-0 md:p-0">
+        <section
+          className="w-[38%] max-w-[168px] shrink-0 overflow-hidden rounded-2xl bg-main-bg md:w-full md:max-w-none md:rounded-none md:rounded-t-card"
+          style={{ aspectRatio: '13 / 14' }}
+        >
+          {member.image ? (
+            <img
+              src={member.image}
+              alt={member.name}
+              className="h-full w-full object-cover block rounded-2xl md:rounded-3xl"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-main-bg to-main-bg/50 rounded-2xl md:rounded-3xl">
+              <div className="text-4xl font-bold text-accent md:text-6xl">
+                {member.name
+                  .split(' ')
+                  .map((n) => n[0])
+                  .join('')}
+              </div>
+            </div>
+          )}
+        </section>
+
+        <section className="flex-1 min-w-0 flex flex-col gap-1 md:px-6 md:py-4">
+          <p className="text-[10px] font-bold uppercase tracking-wider text-accent mb-0">
+            {member.role}
+          </p>
+          <div className="flex items-center gap-2 flex-wrap min-h-[1.125rem]">
+            <h3 className="text-base md:text-xl font-bold text-main-text leading-tight mb-0">
+              {member.name}
+            </h3>
+            {member.linkedin ? (
+              <a
+                href={member.linkedin}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-main-text shrink-0 flex items-center justify-center hover:opacity-80 [&>svg]:block"
+                aria-label={`${member.name} on LinkedIn`}
+              >
+                <LinkedInIcon />
+              </a>
+            ) : (
+              <span
+                className="text-main-text shrink-0 flex items-center [&>svg]:block"
+                aria-hidden
+              >
+                <LinkedInIcon />
+              </span>
+            )}
+          </div>
+          {member.bio ? (
+            <p className="text-sm leading-snug text-main-text mt-2 whitespace-pre-line mb-0">
+              {member.bio}
+            </p>
+          ) : null}
+        </section>
+      </div>
+    </article>
+  );
+}
+
 export default function TeamMemberCard({
   member,
   onClick,
@@ -34,6 +105,11 @@ export default function TeamMemberCard({
   const bioId = `member-bio-${member.id}`;
   const isExecutive = member.category === 'executive';
 
+  // Executives: static layout per mobile Figma (no expand / no hover scale)
+  if (isExecutive) {
+    return <ExecutiveCard member={member} />;
+  }
+
   const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
@@ -41,18 +117,15 @@ export default function TeamMemberCard({
     }
   };
 
-  // Expanded profile view
+  // Expanded profile view (team leads only)
   if (isExpanded) {
     return (
       <button
         type="button"
-        className={`rounded-card cursor-pointer flex flex-col bg-main-bg w-full text-left transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-main-bg overflow-hidden ${
-          isExecutive ? 'border-2 border-gray-600' : ''
-        }`}
+        className="rounded-card cursor-pointer flex flex-col bg-main-bg w-full text-left overflow-hidden col-span-full focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-main-bg"
         style={{
-          boxShadow: isExecutive
-            ? '0 0 40px rgba(254, 206, 0, 0.2), 0 0 80px rgba(0, 0, 0, 0.5), 0 0 20px rgba(75, 85, 99, 0.4), 0 0 40px rgba(75, 85, 99, 0.2)'
-            : '0 0 40px rgba(254, 206, 0, 0.2), 0 0 80px rgba(0, 0, 0, 0.5)',
+          boxShadow:
+            '0 0 40px rgba(254, 206, 0, 0.2), 0 0 80px rgba(0, 0, 0, 0.5)',
         }}
         onClick={onClick}
         onKeyDown={handleKeyDown}
@@ -62,12 +135,10 @@ export default function TeamMemberCard({
         aria-describedby={bioId}
         id={modalId}
       >
-        {/* Top Section - fixed size, same as collapsed card */}
         <section
           className="w-full rounded-t-card overflow-hidden bg-main-bg flex flex-col p-4"
           style={{ aspectRatio: '13 / 14' }}
         >
-          {/* Name - Bold White with LinkedIn icon */}
           <div className="flex items-center gap-2 min-h-[1.125rem]">
             <h2
               id={nameId}
@@ -80,7 +151,7 @@ export default function TeamMemberCard({
                 href={member.linkedin}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-main-text shrink-0 flex items-center justify-center hover:opacity-80 transition-opacity [&>svg]:block"
+                className="text-main-text shrink-0 flex items-center justify-center hover:opacity-80 [&>svg]:block"
                 aria-label={`${member.name} on LinkedIn`}
                 onClick={(e) => e.stopPropagation()}
               >
@@ -96,15 +167,10 @@ export default function TeamMemberCard({
             )}
           </div>
 
-          {/* Role - Yellow */}
-          <p
-            className="text-[10px] font-bold uppercase tracking-wider mb-1"
-            style={{ color: '#FECE00' }}
-          >
+          <p className="text-[10px] font-bold uppercase tracking-wider mb-1 text-accent">
             {member.role}
           </p>
 
-          {/* Bio - larger than collapsed, sized to fit card without scroll */}
           {member.bio && (
             <div
               id={bioId}
@@ -117,36 +183,22 @@ export default function TeamMemberCard({
           )}
         </section>
 
-        {/* Bottom Section - Same as text section in collapsed card */}
-        <section className="w-full bg-main-bg rounded-b-card px-6 py-4">
-          {/* Spacer to match collapsed card's text section height */}
-        </section>
+        <section className="w-full bg-main-bg rounded-b-card px-6 py-4" />
       </button>
     );
   }
 
-  // Collapsed card view
+  // Collapsed card view (team leads)
   return (
     <button
       type="button"
-      className={`rounded-card cursor-pointer hover:scale-105 transition-transform flex flex-col bg-main-bg w-full text-left focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-main-bg ${
-        isExecutive ? 'border-2 border-gray-600' : ''
-      }`}
-      style={
-        isExecutive
-          ? {
-              boxShadow:
-                '0 0 20px rgba(75, 85, 99, 0.4), 0 0 40px rgba(75, 85, 99, 0.2)',
-            }
-          : undefined
-      }
+      className="rounded-card cursor-pointer hover:scale-105 transition-transform flex flex-col bg-main-bg w-full text-left focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-main-bg"
       onClick={onClick}
       onKeyDown={handleKeyDown}
       aria-haspopup="dialog"
       aria-controls={modalId}
       aria-label={`View ${member.name}'s profile`}
     >
-      {/* Picture Section - Separate and on top */}
       <section
         className="w-full rounded-t-card overflow-hidden bg-main-bg relative"
         style={{ aspectRatio: '13 / 14' }}
@@ -169,19 +221,13 @@ export default function TeamMemberCard({
         )}
       </section>
 
-      {/* Text Section - Separate and below picture */}
-      <section className="w-full bg-main-bg rounded-b-card px-6 py-4 text-center">
-        {/* Blue Role Text */}
-        <p
-          className="text-sm font-bold uppercase mb-0"
-          style={{ color: '#007BFF' }}
-        >
+      <section className="w-full bg-main-bg rounded-b-card px-2 py-3 sm:px-6 sm:py-4 text-center">
+        <p className="text-xs sm:text-sm font-bold uppercase mb-0 text-role-blue">
           {member.role}
         </p>
 
-        {/* White Name Text with LinkedIn icon */}
-        <div className="flex items-center justify-center gap-2 min-h-[1.125rem]">
-          <h3 className="text-xl font-bold text-main-text leading-none">
+        <div className="flex items-center justify-center gap-1 sm:gap-2 min-h-[1.125rem] flex-wrap">
+          <h3 className="text-sm sm:text-lg md:text-xl font-bold text-main-text leading-tight">
             {member.name}
           </h3>
           {member.linkedin ? (
@@ -189,7 +235,7 @@ export default function TeamMemberCard({
               href={member.linkedin}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-main-text shrink-0 flex items-center justify-center hover:opacity-80 transition-opacity [&>svg]:block"
+              className="text-main-text shrink-0 flex items-center justify-center hover:opacity-80 [&>svg]:block"
               aria-label={`${member.name} on LinkedIn`}
               onClick={(e) => e.stopPropagation()}
             >

--- a/src/data/teamMembers.ts
+++ b/src/data/teamMembers.ts
@@ -25,7 +25,7 @@ export const teamMembers: TeamMember[] = [
     category: 'executive',
     major: 'Computer Science',
     year: 'Senior',
-    bio: 'Blurb here',
+    bio: 'A 3rd year Aerospace & Robotics Engineering student, Abhinav is a patented inventor, writer, YouTuber, and Entrepreneur. At age 14 he created a book donation app, at 17 he set up a company for his invention -- a wearable app for pregnant women.',
     email: 'johndoe@ucsd.edu',
     image: abhinavSwarupImg,
     linkedin: 'https://www.linkedin.com/in/abhinav-swarup-7284b1236',

--- a/src/pages/Advisor/Advisor.tsx
+++ b/src/pages/Advisor/Advisor.tsx
@@ -12,7 +12,8 @@ import advisoryHeroImg from '../../imgs/advisors-page/hero/advisory-hero.webp';
 const CONTAINER = 'w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-left';
 const SECTION_WRAPPER = 'py-16';
 const SECTION_TITLE = 'text-left mb-12';
-const GRID = 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-14';
+/** Mobile: two-column advisor cards per Figma V2 mobile. */
+const GRID = 'grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 gap-7 md:gap-14';
 
 function AdvisorCard({ name, department, image }: Advisor) {
   return (
@@ -27,14 +28,11 @@ function AdvisorCard({ name, department, image }: Advisor) {
           className="w-full h-full object-cover block rounded-3xl"
         />
       </div>
-      <section className="w-full bg-main-bg rounded-b-card px-6 py-4 text-left">
-        <CardTitle className="text-sm md:text-base font-bold text-white leading-tight">
+      <section className="w-full bg-main-bg rounded-b-card px-2 py-3 sm:px-6 sm:py-4 text-left">
+        <CardTitle className="text-xs sm:text-sm md:text-base font-bold text-white leading-tight">
           {name}
         </CardTitle>
-        <p
-          className="mt-1 text-sm md:text-base leading-relaxed"
-          style={{ color: '#FECE00' }}
-        >
+        <p className="mt-1 text-xs sm:text-sm md:text-base leading-relaxed text-accent">
           {department}
         </p>
       </section>

--- a/src/pages/Alumni/Alumni.tsx
+++ b/src/pages/Alumni/Alumni.tsx
@@ -11,7 +11,8 @@ import SEO from '../../components/SEO';
 // Shared layout constants for consistent spacing
 const SECTION_WRAPPER = 'py-16';
 const CONTAINER = 'w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8';
-const GRID = 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-14';
+/** Mobile: two-column cards per Figma V2 mobile; tighter gutter (~28px). */
+const GRID = 'grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 gap-7 md:gap-14';
 
 export default function Alumni() {
   const executives = alumniMembers.filter((m) => m.category === 'executive');

--- a/src/pages/Team/Team.tsx
+++ b/src/pages/Team/Team.tsx
@@ -12,7 +12,11 @@ import teamPhoto from '../../imgs/hero/team-hero.webp';
 // Shared layout constants for consistent spacing
 const SECTION_WRAPPER = 'py-16';
 const CONTAINER = 'w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8';
-const GRID = 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-14';
+/** Executives keep a single column on small phones (detailed cards); 2+ cols from sm. */
+const GRID_EXECUTIVES = 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-14';
+/** Team Leads: Figma mobile — two columns, ~28px gutter; align with V2 mobile design. */
+const GRID_TEAM_LEADS =
+  'grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 gap-7 md:gap-14';
 
 export default function Team() {
   const [selectedMember, setSelectedMember] = useState<TeamMember | null>(null);
@@ -58,7 +62,7 @@ export default function Team() {
           <SectionHeading className="text-left mb-8">
             Our Executives
           </SectionHeading>
-          <div className={GRID}>
+          <div className={GRID_EXECUTIVES}>
             {executives.map((member) => (
               <TeamMemberCard
                 key={member.id}
@@ -80,7 +84,7 @@ export default function Team() {
           <SectionHeading className="text-left mb-8">
             Our Team Leads
           </SectionHeading>
-          <div className={GRID}>
+          <div className={GRID_TEAM_LEADS}>
             {teamLeads.map((member) => (
               <TeamMemberCard
                 key={member.id}


### PR DESCRIPTION
Implements [issue #104](https://github.com/triton-droids/website/issues/104).

### Changes
- **Team / Alumni / Advisor pages:** two-column card grids on mobile with tighter gap (Figma V2 mobile).
- **Executive cards:** horizontal layout on small viewports, yellow role, full bio; no hover scale or expand interaction.
- **Alumni & advisor cards:** responsive padding/typography for narrow columns.
- **Data:** real bio copy for Abhinav (replaces placeholder).

### Verification
- `npm run build` passes.

Made with [Cursor](https://cursor.com)