### PR TITLE
fix: stabilize Playwright carousel tests with explicit assertions

### DIFF
--- a/e2e/carousel-closeup.spec.ts
+++ b/e2e/carousel-closeup.spec.ts
@@ -1,90 +1,65 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Carousel Close-up Screenshots', () => {
   test('Take close-up screenshots of carousel cards', async ({ page }) => {
-    // Set viewport to desktop size for best typography view
     await page.setViewportSize({ width: 1920, height: 1080 });
 
-    // AchieveSection carousel
     await page.goto('/');
-    await page
-      .locator('h2:has-text("How We Aim to Achieve Our Mission")')
-      .scrollIntoViewIfNeeded();
-    await page.waitForSelector(
-      'h3:has-text("Leveraging UCSD\'s Unique Assets")',
-      { timeout: 10000 }
-    );
-    await page.waitForTimeout(1000);
 
-    // Get the actual card element (the dark container with content)
-    const achieveCard = page
-      .getByTestId('achieve-carousel-desktop')
-      .locator('div[class*="bg-[#2A2B2D]"]')
-      .filter({
-        has: page.locator('h3:has-text("Leveraging UCSD\'s Unique Assets")'),
-      })
-      .first();
+    const achieveDesktop = page.getByTestId('achieve-carousel-desktop');
+    const achieveHeading = page.getByRole('heading', {
+      level: 2,
+      name: 'How We Aim to Achieve Our Mission',
+    });
+    const firstAchieveTitle = achieveDesktop.getByRole('heading', {
+      level: 3,
+      name: "Leveraging UCSD's Unique Assets",
+    });
+    const firstAchieveSlide = achieveDesktop.getByTestId('achieve-slide-1');
 
-    await achieveCard.screenshot({
+    await achieveHeading.scrollIntoViewIfNeeded();
+    await expect(firstAchieveTitle).toBeVisible();
+
+    await firstAchieveSlide.screenshot({
       path: 'e2e/screenshots/achieve-card-closeup.png',
     });
 
-    console.log('AchieveSection card close-up saved');
-
-    // WhyJoinCarousel
     await page.goto('/join');
-    await page
-      .locator('h2:has-text("Why join Triton Droids?")')
-      .scrollIntoViewIfNeeded();
-    await page.waitForSelector('h3:has-text("Real world impact")', {
-      timeout: 10000,
+    const joinCarousel = page.getByTestId('why-join-carousel');
+    const joinHeading = joinCarousel.getByRole('heading', {
+      level: 2,
+      name: 'Why join Triton Droids?',
     });
-    await page.waitForTimeout(1000);
+    const firstJoinTitle = joinCarousel.getByRole('heading', {
+      level: 3,
+      name: 'Real world impact',
+    });
+    const firstJoinSlide = joinCarousel.getByTestId('why-join-slide-1');
 
-    const joinCard = page
-      .locator('div[class*="bg-[#2A2B2D]"]')
-      .filter({
-        has: page.locator('h3:has-text("Real world impact")'),
-      })
-      .first();
-
-    await joinCard.screenshot({
+    await joinHeading.scrollIntoViewIfNeeded();
+    await expect(firstJoinTitle).toBeVisible();
+    await firstJoinSlide.screenshot({
       path: 'e2e/screenshots/join-card-closeup.png',
     });
 
-    console.log('WhyJoinCarousel card close-up saved');
-
-    // Test clicking next button to see another slide
     await page.goto('/');
-    await page
-      .locator('h2:has-text("How We Aim to Achieve Our Mission")')
-      .scrollIntoViewIfNeeded();
-    await page.waitForSelector(
-      'h3:has-text("Leveraging UCSD\'s Unique Assets")',
-      { timeout: 10000 }
-    );
-    await page.waitForTimeout(1000);
 
-    // Click the next arrow (desktop carousel; mobile also has Next in DOM)
-    const nextButton = page
-      .getByTestId('achieve-carousel-desktop')
-      .locator('button[aria-label="Next slide"]');
+    const nextButton = achieveDesktop.getByRole('button', {
+      name: 'Next slide',
+    });
+    const secondSlideTitle = achieveDesktop.getByRole('heading', {
+      level: 3,
+      name: 'Focus on Equity and Global Impact',
+    });
+    const secondSlide = achieveDesktop.getByTestId('achieve-slide-2');
+
+    await achieveHeading.scrollIntoViewIfNeeded();
+    await expect(firstAchieveTitle).toBeVisible();
     await nextButton.click();
-    await page.waitForTimeout(1000);
+    await expect(secondSlideTitle).toBeVisible();
 
-    // Screenshot the second slide
-    const secondSlideCard = page
-      .getByTestId('achieve-carousel-desktop')
-      .locator('div[class*="bg-[#2A2B2D]"]')
-      .filter({
-        has: page.locator('h3:has-text("Focus on Equity")'),
-      })
-      .first();
-
-    await secondSlideCard.screenshot({
+    await secondSlide.screenshot({
       path: 'e2e/screenshots/achieve-card-slide2.png',
     });
-
-    console.log('Second slide screenshot saved');
   });
 });

--- a/e2e/carousel-typography.spec.ts
+++ b/e2e/carousel-typography.spec.ts
@@ -5,16 +5,14 @@ test.describe('Carousel Typography', () => {
     await page.goto('/');
 
     const desktopAchieve = page.getByTestId('achieve-carousel-desktop');
+    const title = desktopAchieve.getByRole('heading', {
+      level: 3,
+      name: "Leveraging UCSD's Unique Assets",
+    });
 
-    // Wait for desktop carousel to be visible (mobile + desktop both mount; target md+ view)
-    await expect(
-      desktopAchieve.locator('h3:has-text("Leveraging UCSD\'s Unique Assets")')
-    ).toBeVisible({ timeout: 10000 });
+    await expect(title).toBeVisible();
 
     // Check title typography
-    const title = desktopAchieve.locator(
-      'h3:has-text("Leveraging UCSD\'s Unique Assets")'
-    );
     await expect(title).toBeVisible();
 
     const titleStyles = await title.evaluate((el) => {
@@ -38,8 +36,8 @@ test.describe('Carousel Typography', () => {
     expect(titleStyles.fontWeight).toBe('400');
 
     // Check bullet point typography
-    const bulletPoint = desktopAchieve.locator(
-      'li span:has-text("Expert Faculty Collaboration")'
+    const bulletPoint = desktopAchieve.getByText(
+      'Expert Faculty Collaboration'
     );
     await expect(bulletPoint).toBeVisible();
 
@@ -67,13 +65,13 @@ test.describe('Carousel Typography', () => {
   test('WhyJoinCarousel has correct typography', async ({ page }) => {
     await page.goto('/join');
 
-    // Wait for carousel to be visible
-    await page.waitForSelector('h3:has-text("Real world impact")', {
-      timeout: 10000,
+    const joinCarousel = page.getByTestId('why-join-carousel');
+    const title = joinCarousel.getByRole('heading', {
+      level: 3,
+      name: 'Real world impact',
     });
 
     // Check title typography
-    const title = page.locator('h3:has-text("Real world impact")').first();
     await expect(title).toBeVisible();
 
     const titleStyles = await title.evaluate((el) => {
@@ -97,9 +95,14 @@ test.describe('Carousel Typography', () => {
     expect(titleStyles.fontWeight).toBe('400');
 
     // Check description typography
-    const description = page
-      .locator('p:has-text("you won\'t just be tinkering")')
-      .first();
+    const firstJoinSlide = joinCarousel.getByTestId('why-join-slide-1');
+    const descriptionToggle = firstJoinSlide.getByRole('button', {
+      name: 'Show description',
+    });
+    await expect(descriptionToggle).toBeVisible();
+    await descriptionToggle.click();
+
+    const description = firstJoinSlide.getByText("you won't just be tinkering");
     await expect(description).toBeVisible();
 
     const descriptionStyles = await description.evaluate((el) => {
@@ -128,11 +131,18 @@ test.describe('Carousel Typography', () => {
     await page.goto('/');
 
     const desktopAchieve = page.getByTestId('achieve-carousel-desktop');
+    const slideOne = desktopAchieve.getByTestId('achieve-slide-1');
+    const slideTwo = desktopAchieve.getByTestId('achieve-slide-2');
+    const nextButton = desktopAchieve.getByRole('button', {
+      name: 'Next slide',
+    });
 
     // Wait for desktop carousel
-    await expect(
-      desktopAchieve.locator('h3:has-text("Leveraging UCSD\'s Unique Assets")')
-    ).toBeVisible({ timeout: 10000 });
+    const firstSlideTitle = desktopAchieve.getByRole('heading', {
+      level: 3,
+      name: "Leveraging UCSD's Unique Assets",
+    });
+    await expect(firstSlideTitle).toBeVisible();
 
     // Take a screenshot for visual verification
     await page.screenshot({
@@ -141,17 +151,8 @@ test.describe('Carousel Typography', () => {
     });
 
     // Check that text doesn't overflow the card
-    const card = desktopAchieve
-      .locator('div')
-      .filter({
-        has: page.locator('h3:has-text("Leveraging UCSD\'s Unique Assets")'),
-      })
-      .first();
-    const cardBox = await card.boundingBox();
-    const title = desktopAchieve.locator(
-      'h3:has-text("Leveraging UCSD\'s Unique Assets")'
-    );
-    const titleBox = await title.boundingBox();
+    const cardBox = await slideOne.boundingBox();
+    const titleBox = await firstSlideTitle.boundingBox();
 
     if (cardBox && titleBox) {
       // Title should be contained within the card
@@ -161,11 +162,34 @@ test.describe('Carousel Typography', () => {
       );
     }
 
+    // Assert navigation actually changes visible content
+    await nextButton.click();
+    const secondSlideTitle = desktopAchieve.getByRole('heading', {
+      level: 3,
+      name: 'Focus on Equity and Global Impact',
+    });
+    await expect(secondSlideTitle).toBeVisible();
+    await expect(slideTwo).toBeVisible();
+
     // Test Why Join carousel
     await page.goto('/join');
-    await page.waitForSelector('h3:has-text("Real world impact")', {
-      timeout: 10000,
+    const joinCarousel = page.getByTestId('why-join-carousel');
+    const joinTitle = joinCarousel.getByRole('heading', {
+      level: 3,
+      name: 'Real world impact',
     });
+    await expect(joinTitle).toBeVisible();
+
+    const joinNextButton = joinCarousel.getByRole('button', {
+      name: 'Next slide',
+    });
+    await joinNextButton.click();
+    await expect(
+      joinCarousel.getByRole('heading', {
+        level: 3,
+        name: 'Hands-on experience',
+      })
+    ).toBeVisible();
 
     await page.screenshot({
       path: 'e2e/screenshots/why-join-carousel.png',

--- a/e2e/carousel-visual.spec.ts
+++ b/e2e/carousel-visual.spec.ts
@@ -1,108 +1,79 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Carousel Visual Testing', () => {
+  const achieveTitle = "Leveraging UCSD's Unique Assets";
+
   test('AchieveSection carousel visual test', async ({ page }) => {
     await page.goto('/');
 
-    // Scroll to the carousel section
-    await page
-      .locator('h2:has-text("How We Aim to Achieve Our Mission")')
-      .scrollIntoViewIfNeeded();
-
-    // Wait for carousel to be visible
-    await page.waitForSelector(
-      'h3:has-text("Leveraging UCSD\'s Unique Assets")',
-      { timeout: 10000 }
-    );
-    await page.waitForTimeout(1000); // Wait for animations
-
-    // Take screenshot of the carousel
-    const carousel = page
-      .locator('div')
-      .filter({
-        has: page.locator('h3:has-text("Leveraging UCSD\'s Unique Assets")'),
-      })
-      .first();
-    await carousel.screenshot({
-      path: 'e2e/screenshots/achieve-carousel-full.png',
+    const achieveDesktop = page.getByTestId('achieve-carousel-desktop');
+    const sectionHeading = page.getByRole('heading', {
+      level: 2,
+      name: 'How We Aim to Achieve Our Mission',
+    });
+    const firstSlideTitle = achieveDesktop.getByRole('heading', {
+      level: 3,
+      name: achieveTitle,
     });
 
-    console.log('AchieveSection carousel screenshot saved');
+    await sectionHeading.scrollIntoViewIfNeeded();
+    await expect(firstSlideTitle).toBeVisible();
+
+    await achieveDesktop.screenshot({
+      path: 'e2e/screenshots/achieve-carousel-full.png',
+    });
   });
 
   test('WhyJoinCarousel visual test', async ({ page }) => {
     await page.goto('/join');
 
-    // Scroll to the carousel section
-    await page
-      .locator('h2:has-text("Why join Triton Droids?")')
-      .scrollIntoViewIfNeeded();
-
-    // Wait for carousel to be visible
-    await page.waitForSelector('h3:has-text("Real world impact")', {
-      timeout: 10000,
+    const joinCarousel = page.getByTestId('why-join-carousel');
+    const sectionHeading = joinCarousel.getByRole('heading', {
+      level: 2,
+      name: 'Why join Triton Droids?',
     });
-    await page.waitForTimeout(1000); // Wait for animations
+    const firstSlideTitle = joinCarousel.getByRole('heading', {
+      level: 3,
+      name: 'Real world impact',
+    });
 
-    // Take screenshot of the carousel
-    const carousel = page
-      .locator('div')
-      .filter({ has: page.locator('h3:has-text("Real world impact")') })
-      .first();
-    await carousel.screenshot({
+    await sectionHeading.scrollIntoViewIfNeeded();
+    await expect(firstSlideTitle).toBeVisible();
+
+    await joinCarousel.getByTestId('why-join-slide-1').screenshot({
       path: 'e2e/screenshots/why-join-carousel-full.png',
     });
-
-    console.log('WhyJoinCarousel screenshot saved');
   });
 
   test('Carousel typography at different viewport sizes', async ({ page }) => {
-    // Test at desktop size (1920x1080)
-    await page.setViewportSize({ width: 1920, height: 1080 });
-    await page.goto('/');
+    const viewports = [
+      { width: 1920, height: 1080, screenshot: 'achieve-carousel-desktop.png' },
+      { width: 768, height: 1024, screenshot: 'achieve-carousel-tablet.png' },
+    ];
 
-    await page
-      .locator('h2:has-text("How We Aim to Achieve Our Mission")')
-      .scrollIntoViewIfNeeded();
-    await page.waitForSelector(
-      'h3:has-text("Leveraging UCSD\'s Unique Assets")',
-      { timeout: 10000 }
-    );
-    await page.waitForTimeout(1000);
+    for (const viewport of viewports) {
+      await page.setViewportSize({
+        width: viewport.width,
+        height: viewport.height,
+      });
+      await page.goto('/');
 
-    const carousel = page
-      .locator('div')
-      .filter({
-        has: page.locator('h3:has-text("Leveraging UCSD\'s Unique Assets")'),
-      })
-      .first();
-    await carousel.screenshot({
-      path: 'e2e/screenshots/achieve-carousel-desktop.png',
-    });
+      const achieveDesktop = page.getByTestId('achieve-carousel-desktop');
+      const sectionHeading = page.getByRole('heading', {
+        level: 2,
+        name: 'How We Aim to Achieve Our Mission',
+      });
+      const firstSlideTitle = achieveDesktop.getByRole('heading', {
+        level: 3,
+        name: achieveTitle,
+      });
 
-    // Test at tablet size (768x1024)
-    await page.setViewportSize({ width: 768, height: 1024 });
-    await page.goto('/');
+      await sectionHeading.scrollIntoViewIfNeeded();
+      await expect(firstSlideTitle).toBeVisible();
 
-    await page
-      .locator('h2:has-text("How We Aim to Achieve Our Mission")')
-      .scrollIntoViewIfNeeded();
-    await page.waitForSelector(
-      'h3:has-text("Leveraging UCSD\'s Unique Assets")',
-      { timeout: 10000 }
-    );
-    await page.waitForTimeout(1000);
-
-    const carouselTablet = page
-      .locator('div')
-      .filter({
-        has: page.locator('h3:has-text("Leveraging UCSD\'s Unique Assets")'),
-      })
-      .first();
-    await carouselTablet.screenshot({
-      path: 'e2e/screenshots/achieve-carousel-tablet.png',
-    });
-
-    console.log('Responsive screenshots saved');
+      await achieveDesktop.screenshot({
+        path: `e2e/screenshots/${viewport.screenshot}`,
+      });
+    }
   });
 });

--- a/e2e/join-carousel-all-slides.spec.ts
+++ b/e2e/join-carousel-all-slides.spec.ts
@@ -1,81 +1,48 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Join Carousel All Slides', () => {
-  test('Capture all 4 slides of Join carousel with highlighting', async ({
-    page,
-  }) => {
+  test('Capture all 4 slides and assert navigation works', async ({ page }) => {
     await page.setViewportSize({ width: 1920, height: 1080 });
-
     await page.goto('/join');
-    await page
-      .locator('h2:has-text("Why join Triton Droids?")')
-      .scrollIntoViewIfNeeded();
-    await page.waitForSelector('h3:has-text("Real world impact")', {
-      timeout: 10000,
+
+    const joinCarousel = page.getByTestId('why-join-carousel');
+    const sectionHeading = joinCarousel.getByRole('heading', {
+      level: 2,
+      name: 'Why join Triton Droids?',
     });
-    await page.waitForTimeout(1000);
+    const nextButton = joinCarousel.getByRole('button', { name: 'Next slide' });
+    const slideTitles = [
+      'Real world impact',
+      'Hands-on experience',
+      'Jobs, internships, and more',
+      'Life long connections',
+    ];
+    const slideScreenshots = [
+      'join-slide-1-real-world-impact.png',
+      'join-slide-2-hands-on.png',
+      'join-slide-3-jobs.png',
+      'join-slide-4-connections.png',
+    ];
 
-    // Slide 1: Real world impact
-    let card = page
-      .locator('div[class*="bg-[#2A2B2D]"]')
-      .filter({
-        has: page.locator('h3:has-text("Real world impact")'),
-      })
-      .first();
-    await card.screenshot({
-      path: 'e2e/screenshots/join-slide-1-real-world-impact.png',
-    });
-    console.log('Slide 1 captured');
+    await sectionHeading.scrollIntoViewIfNeeded();
 
-    // Click next for Slide 2
-    let nextButton = page.locator('button[aria-label="Next slide"]').first();
-    await nextButton.click();
-    await page.waitForTimeout(1500);
+    for (let index = 0; index < slideTitles.length; index += 1) {
+      const title = joinCarousel.getByRole('heading', {
+        level: 3,
+        name: slideTitles[index],
+      });
+      const activeSlide = joinCarousel.getByTestId(
+        `why-join-slide-${index + 1}`
+      );
 
-    // Slide 2: Hands-on experience
-    card = page
-      .locator('div[class*="bg-[#2A2B2D]"]')
-      .filter({
-        has: page.locator('h3:has-text("Hands-on experience")'),
-      })
-      .first();
-    await card.screenshot({
-      path: 'e2e/screenshots/join-slide-2-hands-on.png',
-    });
-    console.log('Slide 2 captured');
+      await expect(title).toBeVisible();
+      await activeSlide.screenshot({
+        path: `e2e/screenshots/${slideScreenshots[index]}`,
+      });
 
-    // Click next for Slide 3
-    nextButton = page.locator('button[aria-label="Next slide"]').first();
-    await nextButton.click();
-    await page.waitForTimeout(1500);
-
-    // Slide 3: Jobs, internships, and more
-    card = page
-      .locator('div[class*="bg-[#2A2B2D]"]')
-      .filter({
-        has: page.locator('h3:has-text("Jobs, internships")'),
-      })
-      .first();
-    await card.screenshot({ path: 'e2e/screenshots/join-slide-3-jobs.png' });
-    console.log('Slide 3 captured');
-
-    // Click next for Slide 4
-    nextButton = page.locator('button[aria-label="Next slide"]').first();
-    await nextButton.click();
-    await page.waitForTimeout(1500);
-
-    // Slide 4: Life long connections
-    card = page
-      .locator('div[class*="bg-[#2A2B2D]"]')
-      .filter({
-        has: page.locator('h3:has-text("Life long connections")'),
-      })
-      .first();
-    await card.screenshot({
-      path: 'e2e/screenshots/join-slide-4-connections.png',
-    });
-    console.log('Slide 4 captured');
-
-    console.log('All 4 Join carousel slides captured with highlighting!');
+      if (index < slideTitles.length - 1) {
+        await nextButton.click();
+      }
+    }
   });
 });

--- a/src/pages/Home/components/AchieveSection.tsx
+++ b/src/pages/Home/components/AchieveSection.tsx
@@ -145,12 +145,13 @@ export default function AchieveSection() {
             className="mx-auto w-full max-w-[min(100%,1400px)]"
             containerClassName="!max-w-none"
             slideClassName="min-w-0 flex-[0_0_92%] lg:flex-[0_0_88%] xl:flex-[0_0_84%] 2xl:flex-[0_0_80%] px-2 sm:px-3 lg:px-4"
-            renderSlide={(slide, _index, tweenValue) => {
+            renderSlide={(slide, index, tweenValue) => {
               const scale = 0.85 + tweenValue * 0.15;
               const opacity = 0.3 + tweenValue * 0.7;
 
               return (
                 <div
+                  data-testid={`achieve-slide-${index + 1}`}
                   className="min-h-0 w-full overflow-hidden py-1 origin-center transition-transform duration-150 ease-out"
                   style={{
                     transform: `scale(${scale})`,

--- a/src/pages/Join/components/WhyJoinCarousel.tsx
+++ b/src/pages/Join/components/WhyJoinCarousel.tsx
@@ -18,7 +18,10 @@ function WhyJoinSlide({ slide }: { slide: Slide }) {
 
   return (
     <div className="w-full">
-      <div className="w-full bg-[#2A2B2D] rounded-[28px] lg:rounded-[40px] flex min-h-[20rem] md:min-h-[36rem] flex-col items-center justify-center text-center gap-6 md:gap-8 px-7 py-10 sm:px-10 sm:py-12 md:px-12 md:py-12 max-w-[1050px] mx-auto">
+      <div
+        className="w-full bg-[#2A2B2D] rounded-[28px] lg:rounded-[40px] flex min-h-[20rem] md:min-h-[36rem] flex-col items-center justify-center text-center gap-6 md:gap-8 px-7 py-10 sm:px-10 sm:py-12 md:px-12 md:py-12 max-w-[1050px] mx-auto"
+        data-testid={`why-join-slide-${slide.id}`}
+      >
         <h3 className="text-[20px] sm:text-2xl md:text-[28px] lg:text-[32px] text-main-text leading-[120%] font-normal max-w-xl mx-auto px-2 text-center">
           {slide.title}
         </h3>
@@ -119,7 +122,10 @@ const slides: Slide[] = [
 
 export default function WhyJoinCarousel() {
   return (
-    <section className="flex flex-col gap-8 md:gap-10 lg:gap-16 xl:gap-20 items-center w-full">
+    <section
+      className="flex flex-col gap-8 md:gap-10 lg:gap-16 xl:gap-20 items-center w-full"
+      data-testid="why-join-carousel"
+    >
       <div className="w-full max-w-[1512px] mx-auto px-6 md:px-12 lg:px-[148px]">
         <SectionHeading className="w-full text-left text-2xl leading-tight sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl">
           Why join Triton Droids?


### PR DESCRIPTION
## Summary
- replace style-coupled carousel selectors and fixed `waitForTimeout` sleeps in the targeted Playwright specs with stable role/test-id locators
- add meaningful assertions for visible slide content and navigation state transitions so failures reflect real regressions
- add carousel slide `data-testid` hooks used by the tests to keep locators resilient across styling changes

## Test plan
- [x] `npm run test:e2e -- e2e/carousel-visual.spec.ts e2e/join-carousel-all-slides.spec.ts e2e/carousel-closeup.spec.ts e2e/carousel-typography.spec.ts`

Closes #158

Made with [Cursor](https://cursor.com)