### PR TITLE
feat(ci): enforce frontend bundle size budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Bundle size budget
+        run: npm run size:check
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ npm run lint:fix      # Auto-fix lint issues
 npm run format        # Prettier
 npm run typecheck     # tsc --noEmit
 npm run test:e2e      # Playwright e2e tests
+npm run size          # Build + enforce bundle size budgets
+npm run size:check    # Check budgets against existing dist/
 ```
 
 ## Project Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ npm run format        # Prettier format
 npm run typecheck     # TypeScript check (tsc --noEmit)
 npm run test:e2e      # Playwright e2e tests
 npm run test:e2e:ui   # Playwright interactive UI
+npm run size          # Build + enforce bundle size budgets
+npm run size:check    # Check budgets against existing dist/
 ```
 
 ## Project Structure

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,17 +13,20 @@ This guide covers development setup, conventions, and best practices for the Tri
 ### Initial Setup
 
 1. Clone the repository:
+
 ```bash
 git clone <repository-url>
 cd website
 ```
 
 2. Install dependencies:
+
 ```bash
 npm install
 ```
 
 3. Start the development server:
+
 ```bash
 npm run dev
 ```
@@ -44,8 +47,37 @@ The application will be available at `http://localhost:5173`
 - **`npm run test:e2e`** - Run end-to-end tests with Playwright
 - **`npm run test:e2e:ui`** - Run tests with interactive UI
 - **`npm run test:e2e:visual`** - Run visual regression tests only
+- **`npm run size`** - Build production output and verify bundle size budgets
+- **`npm run size:check`** - Run bundle size budgets against an existing `dist/` (used in CI after `npm run build`)
 
 For detailed testing documentation, see [Testing Guide](./testing.md).
+
+### Bundle size budgets
+
+Production JavaScript and CSS bundles are checked with [size-limit](https://github.com/ai/size-limit) so pull requests cannot grow the main entry assets without an intentional budget update.
+
+**Run locally** (builds first, then checks):
+
+```bash
+npm run size
+```
+
+**Check an existing build** (same command CI runs after `npm run build`):
+
+```bash
+npm run build
+npm run size:check
+```
+
+Budgets are defined in `package.json` under `size-limit`. Limits use **gzip transfer size** for the hashed Vite entry files (`dist/assets/index-*.js` and `dist/assets/index-*.css`).
+
+**Update budgets** when a change legitimately increases bundle size:
+
+1. Run `npm run size` and note the reported sizes.
+2. Raise the corresponding `limit` in `package.json` with modest headroom (roughly 5–15% above the new gzip size).
+3. Include the budget change in your PR description so reviewers know the increase was intentional.
+
+CI runs `npm run size:check` in the build job and fails the workflow when any limit is exceeded.
 
 ### Code Quality
 
@@ -58,6 +90,7 @@ npm run lint
 ```
 
 Common issues are automatically fixable:
+
 ```bash
 npm run lint:fix
 ```
@@ -65,11 +98,13 @@ npm run lint:fix
 #### Formatting
 
 Code is formatted with Prettier. Format all files:
+
 ```bash
 npm run format
 ```
 
 Check formatting without making changes:
+
 ```bash
 npm run format:check
 ```
@@ -102,6 +137,7 @@ src/
 - Avoid `any` types - use proper typing
 
 **Example:**
+
 ```tsx
 interface ComponentProps {
   title: string;
@@ -109,7 +145,11 @@ interface ComponentProps {
   className?: string;
 }
 
-export default function Component({ title, description, className = '' }: ComponentProps) {
+export default function Component({
+  title,
+  description,
+  className = '',
+}: ComponentProps) {
   return <div className={className}>{title}</div>;
 }
 ```
@@ -121,6 +161,7 @@ export default function Component({ title, description, className = '' }: Compon
 - Use descriptive, semantic names
 
 **Examples:**
+
 - ✅ `HeroSection.tsx` → `HeroSection`
 - ✅ `JoinCTASection.tsx` → `JoinCTASection`
 - ❌ `hero.tsx` → `Hero`
@@ -140,15 +181,15 @@ export default function Component({ title, description, className = '' }: Compon
 - Use responsive prefixes (`md:`, `lg:`, `xl:`)
 
 **Example:**
+
 ```tsx
-<div className="flex flex-col md:flex-row gap-4 md:gap-6">
-  {/* Content */}
-</div>
+<div className="flex flex-col md:flex-row gap-4 md:gap-6">{/* Content */}</div>
 ```
 
 #### Custom Colors
 
 Use color tokens from `tailwind.config.js`:
+
 - `bg-main-bg` - Main background
 - `text-main-text` - Main text color
 - `text-muted-text` - Muted text
@@ -158,6 +199,7 @@ Use color tokens from `tailwind.config.js`:
 #### Typography
 
 **Always use Typography components** instead of raw HTML:
+
 - `HeroHeading` for h1
 - `SectionHeading` for h2
 - `CardTitle` for h3
@@ -172,6 +214,7 @@ See [Typography Documentation](./typography.md) for details.
 - Use responsive Tailwind classes
 
 **Breakpoints:**
+
 - `md:` - 768px and up (tablets)
 - `lg:` - 1024px and up (desktops)
 - `xl:` - 1280px and up (large desktops)
@@ -191,9 +234,11 @@ The project uses React Router for client-side routing.
 
 1. Create a page component in `src/pages/`
 2. Add route in `src/App.tsx`:
+
 ```tsx
 <Route path="/new-page" element={<NewPage />} />
 ```
+
 3. Add navigation link in `src/components/Header.tsx` if needed
 
 ## Dev Container
@@ -207,6 +252,7 @@ The project includes a Dev Container configuration for VS Code.
 3. Or use Command Palette: `Dev Containers: Reopen in Container`
 
 The container automatically:
+
 - Sets up the development environment
 - Installs dependencies
 - Configures the workspace
@@ -223,6 +269,7 @@ The container automatically:
 ### Commit Messages
 
 Use clear, descriptive commit messages:
+
 - ✅ `feat: add typography system components`
 - ✅ `fix: resolve carousel animation issue`
 - ✅ `docs: update development guide`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -336,7 +336,7 @@ test('Works on different viewport sizes', async ({ page }) => {
 
 ### GitHub Actions Jobs
 
-1. **Build Job** (existing) - Checkout, install deps, lint, build production bundle
+1. **Build Job** (existing) - Checkout, install deps, lint, typecheck, format check, build production bundle, enforce bundle size budgets (`npm run size:check`)
 2. **Test Job** - Checkout, install deps, install Playwright browsers, run E2E tests; on failure uploads HTML report, screenshots, and `test-results/` artifacts
 
 ### CI Configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.59.1",
+        "@size-limit/file": "^12.1.0",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@typescript-eslint/eslint-plugin": "^8.59.0",
@@ -38,6 +39,7 @@
         "lint-staged": "^15.5.2",
         "postcss": "^8.5.10",
         "prettier": "^3.8.3",
+        "size-limit": "^12.1.0",
         "tailwindcss": "^3.3.6",
         "typescript": "^5.9.3",
         "vite": "^7.3.2"
@@ -1580,6 +1582,19 @@
         "win32"
       ]
     },
+    "node_modules/@size-limit/file": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.1.0.tgz",
+      "integrity": "sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2374,6 +2389,16 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/call-bind": {
@@ -4547,13 +4572,15 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
-        "jiti": "bin/jiti.js"
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-tokens": {
@@ -5065,6 +5092,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
       }
     },
     "node_modules/natural-compare": {
@@ -6286,6 +6323,34 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/size-limit": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.1.0.tgz",
+      "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
@@ -6624,6 +6689,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tailwindcss/node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/tailwindcss/node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -6676,14 +6751,14 @@
       "peer": true
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -6711,9 +6786,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,24 @@
     "prepare": "husky",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:visual": "playwright test carousel-visual.spec.ts"
+    "test:e2e:visual": "playwright test carousel-visual.spec.ts",
+    "size": "npm run build && size-limit",
+    "size:check": "size-limit"
   },
+  "size-limit": [
+    {
+      "name": "Main JS bundle (gzip)",
+      "path": "dist/assets/index-*.js",
+      "limit": "450 KB",
+      "gzip": true
+    },
+    {
+      "name": "Main CSS bundle (gzip)",
+      "path": "dist/assets/index-*.css",
+      "limit": "12 KB",
+      "gzip": true
+    }
+  ],
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix --max-warnings 0",
@@ -40,6 +56,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.59.1",
+    "@size-limit/file": "^12.1.0",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@typescript-eslint/eslint-plugin": "^8.59.0",
@@ -57,6 +74,7 @@
     "lint-staged": "^15.5.2",
     "postcss": "^8.5.10",
     "prettier": "^3.8.3",
+    "size-limit": "^12.1.0",
     "tailwindcss": "^3.3.6",
     "typescript": "^5.9.3",
     "vite": "^7.3.2"


### PR DESCRIPTION
## Summary
- Adds `size-limit` with gzip budgets for the main Vite entry JS (~450 KB) and CSS (~12 KB) bundles
- Runs `npm run size:check` in the CI build job after `npm run build`
- Documents local verification and how to intentionally raise budgets in `docs/development.md`

Closes #164

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run size:check` passes on current production output
- [x] Verified `size:check` fails when limits are lowered below current gzip sizes

Made with [Cursor](https://cursor.com)